### PR TITLE
Support Laravel 7.x, drop Laravel 5.5.x and PHP 7.1 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: php
 
 php:
-  - '7.1'
   - '7.2'
+  - '7.3'
+  - '7.4'
 
 services:
   - mysql

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `laravel-migrate-check` will be documented in this file
 
+## 2.0.0
+
+- Add Laravel 7.x support
+- Drop Laravel 5.5.x and PHP 7.1 support
+
 ## 1.3.0 - 2019-10-17
 
 - Add Laravel 6.x support

--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,14 @@
         }
     ],
     "require": {
-        "php": "^7.1",
-        "illuminate/console": "^5.5.17 | ^6.0",
-        "illuminate/events": "^5.5.17 | ^6.0"
+        "php": "^7.2",
+        "illuminate/console": "5.6.* || 5.7.* || 5.8.* || ^6.0 || ^7.0",
+        "illuminate/events": "5.6.* || 5.7.* || 5.8.* || ^6.0 || ^7.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",
-        "orchestra/testbench": "~3.0",
-        "phpunit/phpunit": "~6.0"
+        "orchestra/testbench": "3.6.* || 3.7.* || 3.8.* || 3.9.* || ^4.0 || ^5.0",
+        "phpunit/phpunit": "^7.5 || ^8.4"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The incompatibilities between Laravel 7 and 5.5 are a bit tough to support.
It can be done through some elaborate hacks and workarounds regarding testing and CI,
but i don't think it's really worth it. The latest 1.x version of this package
already works beautifully for older Laravel installs.